### PR TITLE
Initial work on test and GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+# TODO:
+# * coverage
+# * Semmle
+
+name: CI
+on:
+  push:
+    paths-ignore:
+    - 'LICENSE'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'LICENSE'
+    - 'README.md'
+jobs:
+  Baseline:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        py: [python3.6, python3.7, python3]  # 3.5 lacks f-strings
+    runs-on: ${{ matrix.os }}
+    env:
+      PYTHON: ${{ matrix.py }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install deps
+      run: |
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install ${PYTHON}
+        ${PYTHON} -m pip install graphviz
+    - name: Run tests
+      run: ${PYTHON} -m unittest

--- a/test/test_regex.py
+++ b/test/test_regex.py
@@ -1,0 +1,52 @@
+import unittest
+
+from src.asm2cfg import asm2cfg
+
+
+class FunctionHeaderTest(unittest.TestCase):
+    def test_unstripped(self):
+        line = 'Dump of assembler code for function test_function:'
+        strip, fun = asm2cfg.get_stripped_and_function_name(line)
+        self.assertFalse(strip)
+        self.assertEqual(fun, 'test_function')
+
+    def test_stripped(self):
+        line = 'Dump of assembler code from 0x555555555faf to 0x555555557008:'
+        strip, fun = asm2cfg.get_stripped_and_function_name(line)
+        self.assertTrue(strip)
+        self.assertEqual(fun, '0x555555555faf-0x555555557008')
+
+
+class CallPatternTest(unittest.TestCase):
+    def setUp(self):
+        self.strip_regex = asm2cfg.get_call_pattern(True)
+        self.unstrip_regex = asm2cfg.get_call_pattern(False)
+
+    def test_stripped_known(self):
+        line = '0x000055555557259c:	addr32 call 0x55555558add0 <_Z19exportDebugifyStats>'
+        call_match = self.strip_regex.match(line)
+        self.assertNotEqual(call_match, None)
+        self.assertEqual(call_match[1], '55555557259c')
+        self.assertEqual(call_match[2], '0x55555558add0 <_Z19exportDebugifyStats>')  # FIXME: keep just symbolic name?
+
+    @unittest.expectedFailure
+    def test_unstripped_known(self):
+        line = '0x000055555557259c <+11340>:	addr32 call 0x55555558add0 <_Z19exportDebugifyStats>'
+        call_match = self.unstrip_regex.match(line)
+        self.assertNotEqual(call_match, None)  # FIXME
+        self.assertEqual(call_match[1], '11340')
+        self.assertEqual(call_match[2], '???')
+
+    def test_stripped_pic(self):
+        line = '0x000055555556fd8c:	call   *0x26a16(%rip)        # 0x5555555967a8'
+        call_match = self.strip_regex.match(line)
+        self.assertNotEqual(call_match, None)
+        self.assertEqual(call_match[1], '55555556fd8c')
+        self.assertEqual(call_match[2], '*0x26a16(%rip)        # 0x5555555967a8')  # FIXME: remove trash
+
+    def test_stripped_nonpic(self):
+        line = '0x0000555555556188:	call   0x555555555542'
+        call_match = self.strip_regex.match(line)
+        self.assertNotEqual(call_match, None)
+        self.assertEqual(call_match[1], '555555556188')
+        self.assertEqual(call_match[2], '0x555555555542')


### PR DESCRIPTION
_Sorry for late call, I had bad Covid_

This is an initial work on adding unittest-based tests to the project. I've only added tests for some regexes for now and as you can see from the results, they already found some bugs. I don't want to start fixing them until we have full coverage though.

I plan to add more tests for regexes and then for `parse_lines`. That would open road for refactoring and then new features.

As for the tests, we can add Codecov integration to track coverage but you have to do some admin work (register project on codecov.io, obtain token and add it to project secrets).