### PR TITLE
More work on tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@
 name: CI
 on:
   push:
-    branches: main
     paths-ignore:
     - 'LICENSE'
     - 'README.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # TODO:
-# * coverage
-# * Semmle
+# * Semmle (lgtm.com)
+# * Pylint
 
 name: CI
 on:
@@ -41,3 +41,32 @@ jobs:
     - name: Linting
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: pipenv run flake8
+  Lint:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON: python3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install deps
+      run: |
+        ${PYTHON} -m pip install pipenv
+        pipenv install --dev
+    - name: Linting
+      run: pipenv run flake8
+  Coverage:
+    needs: [Lint, Baseline]
+    runs-on: ubuntu-latest
+    env:
+      PYTHON: python3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install deps
+      run: |
+        ${PYTHON} -m pip install pipenv
+        pipenv install --dev
+    - name: Run tests
+      run: pipenv run pytest --cov-report xml --cov=src test/
+    - name: Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,36 +32,25 @@ jobs:
         ${PYTHON} -m pip install pipenv
         pipenv install --dev
     - name: Run tests
-      run: pipenv run pytest --cov-report xml --cov=src test/
-    - name: Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./coverage.xml
-    - name: Linting
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: pipenv run flake8
+      run: pipenv run pytest test/
   Lint:
     runs-on: ubuntu-latest
-    env:
-      PYTHON: python3
     steps:
     - uses: actions/checkout@v2
     - name: Install deps
       run: |
-        ${PYTHON} -m pip install pipenv
+        python3 -m pip install pipenv
         pipenv install --dev
     - name: Linting
       run: pipenv run flake8
   Coverage:
     needs: [Lint, Baseline]
     runs-on: ubuntu-latest
-    env:
-      PYTHON: python3
     steps:
     - uses: actions/checkout@v2
     - name: Install deps
       run: |
-        ${PYTHON} -m pip install pipenv
+        python3 -m pip install pipenv
         pipenv install --dev
     - name: Run tests
       run: pipenv run pytest --cov-report xml --cov=src test/

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist/
 Pipfile.lock
 
 # Vim files
-.*.swp
+.*swp
 Session.vim
 
 # GDB history
@@ -19,3 +19,6 @@ Session.vim
 # Reporting
 coverage.xml
 .coverage
+
+# Test files
+a.out

--- a/test/templates/call.c
+++ b/test/templates/call.c
@@ -1,0 +1,10 @@
+__attribute__((noinline))
+#ifdef HIDDEN
+__attribute__((visibility("hidden")))
+#endif
+void foo() {
+}
+
+void bar() {
+  foo();
+}

--- a/test/templates/common.py
+++ b/test/templates/common.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+import re
+import os
+
+_me = os.path.basename(__file__)
+v = 0
+
+
+def set_basename(file):
+    global _me
+    _me = file
+
+
+def error(msg):
+    """
+    Print nicely-formatted error message and exit.
+    """
+    sys.stderr.write(f'{_me}: error: {msg}\n')
+    sys.exit(1)
+
+
+def run(cmd, stdin=None):
+    if v:
+        print(f"{_me}: running command: {' '.join(cmd)}")
+    with subprocess.Popen(cmd, stdin=stdin, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE) as p:
+        out, err = p.communicate()
+    out = out.decode()
+    err = err.decode()
+    if p.returncode != 0:
+        cmds = ' '.join(cmd)
+        error(f"'{cmds}' failed:\n{out}{err}")
+    sys.stderr.write(err)
+    return out
+
+
+def gcc(args):
+    return run(['gcc'] + args)
+
+
+def disasm(file):
+    return run(['objdump', '-d', file])
+
+
+def grep(s, regex):
+    lines = s.split('\n')
+    return list(filter(lambda s: re.search(regex, s), lines))
+
+
+def find_address(file, name):
+    out = run(['readelf', '-sW', file])
+    lines = grep(out, fr'{name}$')
+    assert len(lines) >= 1, f"failed to locate symbol {name} in\n{out}"
+    line = lines[0]
+    #   Num:    Value          Size Type    Bind   Vis      Ndx Name
+    #    27: 0000000000001030    11 FUNC    GLOBAL DEFAULT    9 foo
+    line = line.strip()
+    words = re.split(r'\s+', line)
+    start = int(words[1], 16)
+    size = int(words[2])
+    return start, start + size

--- a/test/templates/gen_calls.py
+++ b/test/templates/gen_calls.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+"""
+Generate different flavors of input assembly for testing.
+"""
+
+import os.path
+
+from common import set_basename, run, gcc, disasm, find_address, grep
+
+set_basename(os.path.basename(__file__))
+
+for gdb in [False, True]:
+    for pic in [False, True]:  # Do we need to test PIE too?
+        for direct in [False, True] if pic else [True]:
+            for strip in [False, True]:
+                # Print config
+
+                disasm_type = 'GDB' if gdb else 'objdump'
+                pic_type = 'position-INdependent' if pic else 'position-dependent'
+                call_type = 'PIC-call' if direct else 'PLT-call'
+                stripped = 'stripped' if strip else 'UNstripped'
+                print(f"Checking {disasm_type} {pic_type} {call_type} {stripped}")
+
+                # Generate object code
+
+                flags = ['call.c', '-o', 'a.out',
+                         '-Wl,--defsym,_start=0', '-nostdlib', '-nostartfiles']
+                # Shlib or executable?
+                if pic:
+                    flags += ['-fPIC', '-shared']
+                # Force non-PLT call for PIC code?
+                if direct and pic:
+                    flags.append('-DHIDDEN')
+                # Include debuginfo?
+                if not strip:
+                    flags.append('-g')
+
+                out = gcc(flags)
+
+                # Generate disasm
+
+                caller = 'bar'
+
+                if gdb:
+                    if strip:
+                        # This is tricky as we can not use symbol name
+                        start, finish = find_address('a.out', caller)
+                        out = run(['gdb', '-batch', '-ex', f'disassemble {start},{finish}', 'a.out'])
+                    else:
+                        out = run(['gdb', '-batch', '-ex', f'disassemble {caller}', 'a.out'])
+                else:
+                    out = disasm('a.out')
+
+                # Print snippets
+
+                headers = grep(out, fr'<{caller}>:|Dump of')
+                print('\n    '.join(['  headers:'] + headers))
+                calls = grep(out, r'call')
+                print('\n    '.join(['  calls:'] + calls))

--- a/test/templates/gen_jumps.py
+++ b/test/templates/gen_jumps.py
@@ -12,36 +12,40 @@ set_basename(os.path.basename(__file__))
 
 for gdb in [False, True]:
     for pic in [False, True]:  # Do we need to test PIE too?
-        for strip in [False, True]:
-            # Print config
+        for opt in [False, True]:
+            for strip in [False, True]:
+                # Print config
 
-            disasm_type = 'GDB' if gdb else 'objdump'
-            pic_type = 'position-INdependent' if pic else 'position-dependent'
-            stripped = 'stripped' if strip else 'UNstripped'
-            print(f"Checking {disasm_type} {pic_type} {stripped}")
+                disasm_type = 'GDB' if gdb else 'objdump'
+                pic_type = 'position-INdependent' if pic else 'position-dependent'
+                opt_type = 'optimized' if opt else 'UNoptimized'
+                stripped = 'stripped' if strip else 'UNstripped'
+                print(f"Checking {disasm_type} {pic_type} {opt_type} {stripped}")
 
-            # Generate object code
+                # Generate object code
 
-            flags = ['jump.c', '-o', 'a.out',
-                     '-Wl,--defsym,_start=0', '-nostdlib', '-nostartfiles']
-            # DLL or executable?
-            if pic:
-                flags += ['-fPIC', '-shared']
-            # Include debuginfo?
-            if not strip:
-                flags.append('-g')
+                flags = ['jump.c', '-o', 'a.out',
+                         '-Wl,--defsym,_start=0', '-nostdlib', '-nostartfiles']
+                # DLL or executable?
+                if pic:
+                    flags += ['-fPIC', '-shared']
+                if opt:
+                    flags.append('-O2')
+                # Include debuginfo?
+                if not strip:
+                    flags.append('-g')
 
-            gcc(flags)
+                gcc(flags)
 
-            # Generate disasm
+                # Generate disasm
 
-            caller = 'bar'
-            out = disasm('a.out', not gdb, strip, caller)
+                caller = 'bar'
+                out = disasm('a.out', not gdb, strip, caller)
 
-            # Print snippets
+                # Print snippets
 
-            jumps = grep(out, r'ju?mp')
-            print('''\
+                jumps = grep(out, r'\bj')
+                print('''\
   jumps:
     {}
 '''.format('\n    '.join(jumps)))

--- a/test/templates/gen_jumps.py
+++ b/test/templates/gen_jumps.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+Generate different flavors of input assembly for testing.
+"""
+
+import os.path
+
+from common import set_basename, run, gcc, disasm, find_address, grep
+
+set_basename(os.path.basename(__file__))
+
+for gdb in [False, True]:
+    for pic in [False, True]:  # Do we need to test PIE too?
+        for strip in [False, True]:
+            # Print config
+
+            disasm_type = 'GDB' if gdb else 'objdump'
+            pic_type = 'position-INdependent' if pic else 'position-dependent'
+            stripped = 'stripped' if strip else 'UNstripped'
+            print(f"Checking {disasm_type} {pic_type} {stripped}")
+
+            # Generate object code
+
+            flags = ['jump.c', '-o', 'a.out',
+                     '-Wl,--defsym,_start=0', '-nostdlib', '-nostartfiles']
+            # Shlib or executable?
+            if pic:
+                flags += ['-fPIC', '-shared']
+            # Include debuginfo?
+            if not strip:
+                flags.append('-g')
+
+            out = gcc(flags)
+
+            # Generate disasm
+
+            if gdb:
+                # This is tricky as we can not use symbol name
+                start, finish = find_address('a.out', 'bar')
+                out = run(['gdb', '-batch', '-ex', f'disassemble {start},{finish}', 'a.out'])
+            else:
+                out = disasm('a.out')
+
+            # Print snippets
+
+            jumps = grep(out, r'ju?mp')
+            print('\n    '.join(['  jumps:'] + jumps))

--- a/test/templates/jump.c
+++ b/test/templates/jump.c
@@ -1,0 +1,6 @@
+int bar(int x) {
+  if (x > 0) {
+    return x + 100;
+  }
+  return x * x;
+}

--- a/test/test_regex.py
+++ b/test/test_regex.py
@@ -4,19 +4,27 @@ from src.asm2cfg import asm2cfg
 
 
 class FunctionHeaderTestCase(unittest.TestCase):
-    def test_unstripped(self):
+    def test_gdb_unstripped(self):
         line = 'Dump of assembler code for function test_function:'
         strip, fun = asm2cfg.get_stripped_and_function_name(line)
 
         self.assertFalse(strip)
         self.assertEqual(fun, 'test_function')
 
-    def test_stripped(self):
+    def test_gdb_stripped(self):
         line = 'Dump of assembler code from 0x555555555faf to 0x555555557008:'
         strip, fun = asm2cfg.get_stripped_and_function_name(line)
 
         self.assertTrue(strip)
         self.assertEqual(fun, '0x555555555faf-0x555555557008')
+
+    @unittest.expectedFailure
+    def test_objdump(self):
+        line = '000000000000100b <bar>:'
+        strip, fun = asm2cfg.get_stripped_and_function_name(line)
+
+        self.assertFalse(strip)
+        self.assertEqual(fun, 'bar')
 
 
 class CallPatternTestCase(unittest.TestCase):
@@ -28,7 +36,7 @@ class CallPatternTestCase(unittest.TestCase):
         line = '0x000055555557259c:	addr32 call 0x55555558add0 <_Z19exportDebugifyStats>'
         call_match = self.strip_regex.match(line)
 
-        self.assertNotEqual(call_match, None)
+        self.assertIsNot(call_match, None)
         self.assertEqual(call_match[1], '55555557259c')
         self.assertEqual(call_match[2], '0x55555558add0 <_Z19exportDebugifyStats>')  # FIXME: keep just symbolic name?
 
@@ -37,7 +45,7 @@ class CallPatternTestCase(unittest.TestCase):
         line = '0x000055555557259c <+11340>:	addr32 call 0x55555558add0 <_Z19exportDebugifyStats>'
         call_match = self.unstrip_regex.match(line)
 
-        self.assertNotEqual(call_match, None)  # FIXME
+        self.assertIsNot(call_match, None)  # FIXME
         self.assertEqual(call_match[1], '11340')
         self.assertEqual(call_match[2], '???')
 
@@ -45,15 +53,33 @@ class CallPatternTestCase(unittest.TestCase):
         line = '0x000055555556fd8c:	call   *0x26a16(%rip)        # 0x5555555967a8'
         call_match = self.strip_regex.match(line)
 
-        self.assertNotEqual(call_match, None)
+        self.assertIsNot(call_match, None)
         self.assertEqual(call_match[1], '55555556fd8c')
         self.assertEqual(call_match[2], '*0x26a16(%rip)        # 0x5555555967a8')  # FIXME: remove trash
+
+    @unittest.expectedFailure
+    def test_objdump_plt(self):
+        line = '1048:	e8 d3 ff ff ff       	callq  1020 <foo@plt>'
+        call_match = self.strip_regex.match(line)
+
+        self.assertIsNot(call_match, None)
+        self.assertEqual(call_match[1], '1048')
+        self.assertEqual(call_match[2], '1020 <foo@plt>')
+
+    @unittest.expectedFailure
+    def test_gdb_plt(self):
+        line = '0x0000000000001048 <bar+13>:	callq  0x1020 <foo@plt>'
+        call_match = self.strip_regex.match(line)
+
+        self.assertIsNot(call_match, None)
+        self.assertEqual(call_match[1], '1048')
+        self.assertEqual(call_match[2], 'callq  0x1020 <foo@plt>')
 
     def test_stripped_nonpic(self):
         line = '0x0000555555556188:	call   0x555555555542'
         call_match = self.strip_regex.match(line)
 
-        self.assertNotEqual(call_match, None)
+        self.assertIsNot(call_match, None)
         self.assertEqual(call_match[1], '555555556188')
         self.assertEqual(call_match[2], '0x555555555542')
 
@@ -64,15 +90,25 @@ class JumpPatternTestCase(unittest.TestCase):
         pattern = asm2cfg.get_jump_pattern(True, 'does_not_matter')
         jump_match = pattern.search(line)
 
-        self.assertNotEqual(jump_match, None)
+        self.assertIsNot(jump_match, None)
         self.assertEqual(jump_match[1], '55555555600f')
         self.assertEqual(jump_match[2], '55555555603d')
+
+    @unittest.expectedFailure
+    def test_objdump(self):
+        line = '1017:	eb 06                	jmp    101f <bar+0x1f>'
+        pattern = asm2cfg.get_jump_pattern(False, 'does_not_matter')
+        jump_match = pattern.search(line)
+
+        self.assertIsNot(jump_match, None)
+        self.assertEqual(jump_match[1], '1017')
+        self.assertEqual(jump_match[2], '101f <bar+0x1f>')
 
     def test_non_stripped_jump(self):
         line = '0x00007ffff7fbf124 <+68>:  jmp  0x7ffff7fbf7c2 <test_function+1762>'
         pattern = asm2cfg.get_jump_pattern(False, 'test_function')
         jump_match = pattern.search(line)
 
-        self.assertNotEqual(jump_match, None)
+        self.assertIsNot(jump_match, None)
         self.assertEqual(jump_match[1], '68')
         self.assertEqual(jump_match[2], '1762')


### PR DESCRIPTION
Some more work on tests. I've added code to generate all (well, not really all, see below) test combinations which resulted in few more tests.

One problem is that with my generators I'm not yet able to generate more complex calls from the `examples/` subdir e.g.
```
call   *0x273a0(%rip)
call   *%rax
call   *0x8(%rax)
addr32 call 0x5555555733e0
call   0x555555576a00
```
I suspect that "stripped" is not just about having the `-g` flag but also stripping the symbol table (via `strip -s`)? Otherwise debugger/objdump still manage to figure out function addresses from `.symtab`.

I also enabled testing on all branches because otherwise it's not possible to test GH actions in PR branches without first submitting them and distracting the maintainer.