### PR TITLE
Fix broken pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
-        py: [python3.7, python3]  # 3.5 lacks f-strings
+        py: [python3.6, python3.7, python3]  # 3.5 lacks f-strings
     runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.py }}
@@ -25,6 +25,17 @@ jobs:
       run: |
         sudo add-apt-repository ppa:deadsnakes/ppa
         scripts/install-deps.sh
+    - name: Install pipenv Ubuntu 18.04
+      # Why specific version of pipenv, check this https://github.com/pypa/pipenv/issues/4829
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+        ${{ matrix.py }} -m pip install pipenv==2021.5.29
+        pipenv install --dev
+    - name: Install pipenv others
+      if: matrix.os != 'ubuntu-18.04'
+      run: |
+        ${{ matrix.py }} -m pip install pipenv
+        pipenv install --dev
     - name: Run tests
       run: pipenv run pytest test/
   Lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install deps
       run: |
+        python3 -m pip install pipenv
         scripts/install-deps.sh
     - name: flake8
       run: pipenv run flake8
@@ -58,6 +59,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install deps
       run: |
+        python3 -m pip install pipenv
         scripts/install-deps.sh
         # Install packages to system python because that will be used by GDB.
         # This is needed so we get correct coverage report when testing GDB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
     - 'LICENSE'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Install deps
       run: |
         python3 -m pip install pipenv
+        pipenv install --dev
         scripts/install-deps.sh
     - name: flake8
       run: pipenv run flake8
@@ -60,6 +61,7 @@ jobs:
     - name: Install deps
       run: |
         python3 -m pip install pipenv
+        pipenv install --dev
         scripts/install-deps.sh
         # Install packages to system python because that will be used by GDB.
         # This is needed so we get correct coverage report when testing GDB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
-        py: [python3.6, python3.7, python3]  # 3.5 lacks f-strings
+        py: [python3.7, python3]  # 3.5 lacks f-strings
     runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.py }}

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -10,5 +10,3 @@ sudo apt-get install $PYTHON gdb graphviz -y
 # Install graphviz globally because of GDB using global python
 # installation and not active pipenv.
 pip3 install graphviz
-$PYTHON -m pip install pipenv
-pipenv install --dev

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -6,7 +6,7 @@ set -x
 PYTHON=${PYTHON:-python3}
 
 sudo apt-get update
-sudo apt-get install $PYTHON gdb graphviz -y
+sudo apt-get install $PYTHON gdb graphviz -y ${PYTHON}-distutils
 # Install graphviz globally because of GDB using global python
 # installation and not active pipenv.
 pip3 install graphviz


### PR DESCRIPTION
Install specific version of Pipenv for Python 3.6 on Ubuntu 18.04. This issue was found in https://github.com/Kazhuu/asm2cfg/pull/28 and is discussed here: https://github.com/pypa/pipenv/issues/4829. Also install `python3.x-distutils` package, because it's seems to be required by latest Ubuntu.