### PR TITLE
Exclude python 3.6 run on Ubuntu 22.04 Jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
         py: [python3.6, python3.7, python3]  # 3.5 lacks f-strings
+        exclude: # Python 3.6 not supported on Ubuntu 22.04 Jammy.
+          - os: ubuntu-latest
+          - py: python3.6
     runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.py }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
         py: [python3.6, python3.7, python3]  # 3.5 lacks f-strings
-        exclude: # Python 3.6 not supported on Ubuntu 22.04 Jammy.
-          - os: ubuntu-latest
-          - py: python3.6
+        exclude:
+          - os: ubuntu-latest # Python 3.6 not supported on Ubuntu 22.04 Jammy.
+            py: python3.6
     runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.py }}


### PR DESCRIPTION
This is needed to fix the currently broken pipeline. Now ubuntu-latest reference the Ubuntu 22.04 Jammy release.